### PR TITLE
Bar graphs are rounding bars to nearest Y axis label number

### DIFF
--- a/lib/SVG/Graph/Bar.rb
+++ b/lib/SVG/Graph/Bar.rb
@@ -117,7 +117,7 @@ module SVG
             #    +ve   -ve  value - 0
             #    -ve   -ve  value.abs - 0
 
-            value = dataset[:data][i]/@y_scale_division
+            value = dataset[:data][i] / @y_scale_division.to_f
 
             left = (fieldwidth * field_count)
 


### PR DESCRIPTION
When `scale_integers` is true, Vertical Bar graphs always round the bars to the nearest axis label number (and dotted line). This wasn't happening with horizontal bar graphs.

The fix was to make the height calculation first convert the `y_scale_division` value to a float before multiplying it with the current value.

See the example before and after the fix.
<img width="934" alt="chart_before" src="https://user-images.githubusercontent.com/180203/30349647-a50eb0f2-97e1-11e7-9cef-41a9a988e645.png">

<img width="760" alt="chart_after" src="https://user-images.githubusercontent.com/180203/30349651-a85b11d8-97e1-11e7-8c6a-c11948d01d9e.png">

