### PR TITLE
show_key_actual_values in pie chart lets user chose to show values in key

### DIFF
--- a/lib/SVG/Graph/Pie.rb
+++ b/lib/SVG/Graph/Pie.rb
@@ -187,7 +187,8 @@ module SVG
           count += 1
           v = @data[count]
           perc = show_key_percent ? " "+(v * percent_scale).round.to_s+"%" : ""
-          x + " [" + v.to_s + "]" + perc
+          val = show_key_actual_values  ? " [" + v.to_s + "]"  : ""
+          x + val + perc
         }
       end
 


### PR DESCRIPTION
For some reasons `:show_key_actual_values` in a pie chart did not do anything. Added one line of code, which adds the value (or not) based on `:show_key_actual_values` analogous to `:show_key_percent`