### PR TITLE
Fix typo in Plot's `scale_y_integers`

### DIFF
--- a/lib/SVG/Graph/Plot.rb
+++ b/lib/SVG/Graph/Plot.rb
@@ -27,7 +27,7 @@ module SVG
     #    	:width => 300,
     #     :key => true,
     #     :scale_x_integers => true,
-    #     :scale_y_integerrs => true,
+    #     :scale_y_integers => true,
     #   })
     #   
     #   graph.add_data({
@@ -105,7 +105,7 @@ module SVG
           :show_lines        => true,
           :round_popups      => true,
           :scale_x_integers  => false,
-          :scale_y_integerrs => false,
+          :scale_y_integers  => false,
          )
       end
 

--- a/test/test_plot.rb
+++ b/test/test_plot.rb
@@ -56,7 +56,7 @@ class TestSvgGraphPlot < Test::Unit::TestCase
       :width => 300,
       :key => true,
       :scale_x_integers => true,
-      :scale_y_integerrs => true,
+      :scale_y_integers => true,
     })
 
     graph.add_data({


### PR DESCRIPTION
Fixes what I believe is a typo in Plot's `scale_y_integers`, which was previously spelt `scale_y_integerrs`. Amends the corresponding test, and I can't find any other instances of the typo in the codebase, so I think the rest is fine.