### PR TITLE
Fix bug in Plot which enabled too-short axis

### DIFF
--- a/lib/SVG/Graph/Plot.rb
+++ b/lib/SVG/Graph/Plot.rb
@@ -262,6 +262,8 @@ module SVG
         min_value, max_value, @x_scale_division = x_label_range
         rv = []
         min_value.step( max_value, @x_scale_division ) {|v| rv << v}
+	# Step is non-inclusive of upper bounds, so add a final value if necessary:
+	rv << rv[-1] + @x_scale_division if rv[-1] < max_value
         return rv
       end
       alias :get_x_labels :get_x_values
@@ -319,6 +321,9 @@ module SVG
         end
         rv = []
         min_value.step( max_value, @y_scale_division ) {|v| rv << v}
+	# Step is non-inclusive of upper bounds, so add a final value if necessary:
+	rv << rv[-1] + @y_scale_division if rv[-1] < max_value
+	# If there is no range to display, add a dummy value
         rv << rv[0] + 1 if rv.length == 1
         return rv
       end


### PR DESCRIPTION
This fixes a bug in Plot which allowed the axis to be insufficiently large to contain the last data point in the event that the last data point does not divide evenly `min_value + n*step`.

Demo of problem:

```
irb(main):041:0> 5.step(10, 2) {|x|puts x}
5
7
9
```

`.step` never goes above the upper bound

Example graph:

<img width="667" alt="screenshot 2019-01-31 at 21 08 06" src="https://user-images.githubusercontent.com/934797/52085414-5d2f0800-259c-11e9-8044-ffa0a5db2146.png">