### PR TITLE
Fix bug in Plot.rb making line 9 invisible

### DIFF
--- a/lib/SVG/Graph/Plot.rb
+++ b/lib/SVG/Graph/Plot.rb
@@ -450,7 +450,7 @@ module SVG
 }
 .line9{
 	fill: none;
-	stroke: #ccc6666;
+	stroke: #cc6666;
 	stroke-width: 1px;
 }
 .line10{


### PR DESCRIPTION
Line 9 had a minor typo in the CSS which resulted in it not displaying; this patches that so lines 1-12 are displayed correctly.

Would you be receptive to a PR which algorithmically generated colours and added them to the CSS for lines > 12 (probably by interpolating between existing colours and #000 #fff to get an optimal spread)? I'd find it very useful for my use case but I understand if you'd rather not support more than 12 lines officially.

Sorry for the small PRs - hope they're not inconvenient!