### PR TITLE
Automatically render graphs in iruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -28,4 +28,5 @@ task :test do
   ruby "test/test_data_point.rb"
   ruby "test/test_plot.rb"
   ruby "test/test_svg_graph.rb"
+  ruby "test/test_graph.rb"
 end

--- a/lib/SVG/Graph/Graph.rb
+++ b/lib/SVG/Graph/Graph.rb
@@ -254,6 +254,14 @@ module SVG
         return out
       end
 
+      # Burns the graph to an SVG string and returns it with a text/html mime type to be
+      # displayed in IRuby.
+      #
+      # @return [Array] A 2-dimension array containing the SVg string and a mime-type. This is the format expected by IRuby.
+      def to_iruby
+        ["text/html", burn_svg_only]
+      end
+
 
       #   Set the height of the graph box, this is the total height
       #   of the SVG box created - not the graph it self which auto

--- a/test/test_graph.rb
+++ b/test/test_graph.rb
@@ -1,0 +1,22 @@
+require 'test/unit'
+require_relative '../lib/svggraph'
+
+class TestGraph < Test::Unit::TestCase
+  class DummyGraph < SVG::Graph::Graph
+    def get_css; end
+    def draw_data; end
+
+    def get_x_labels
+      []
+    end
+    def get_y_labels
+      []
+    end
+  end
+  
+  def test_to_iruby
+    graph = DummyGraph.new({})
+    graph.add_data({ data: [1,2,3] })
+    assert_equal graph.to_iruby, ["text/html", graph.burn_svg_only]
+  end
+end


### PR DESCRIPTION
When using svg-graph in iRuby you currently have to use `IRuby.display(graph, mime: 'text/html')`. This PR addes a `to_svg` method to the `Graph` class which returns the SVG string as well as the mime type for the graph. IRuby will look for this method and  automatically render the graph in a Jupyter notebook.

This resolves #13 