### PR TITLE
Divizion by zero when data is 0,0

### DIFF
--- a/lib/SVG/Graph/Pie.rb
+++ b/lib/SVG/Graph/Pie.rb
@@ -224,7 +224,7 @@ module SVG
         rad_mult = 3.6 * RADIANS
         @config[:fields].each_index { |count|
           value = @data[count].to_f
-          percent = 100.0 * value / total
+          percent = total.zero? ? 0.0 : 100.0 * value / total
           radians = prev_percent * rad_mult
 
           if percent.rationalize(0.001) == 100.0


### PR DESCRIPTION
Added exception to `FloatDomainError (NaN)` on Pie.rb:230