### PR TITLE
Add test-unit to Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ end
 group :test do
   gem 'minitest'
   gem 'minitest-reporters'
+  gem 'test-unit'
 end


### PR DESCRIPTION
At least on recent Ruby versions, test-unit needs to be loaded from the Gemfile in order to run tests.