### PR TITLE
Remove inline styling for data point labels and popups

### DIFF
--- a/lib/SVG/Graph/Graph.rb
+++ b/lib/SVG/Graph/Graph.rb
@@ -530,10 +530,10 @@ module SVG
           t = @foreground.add_element( "text", {
             "x" => tx.to_s,
             "y" => (y - font_size).to_s,
-            "class" => "dataPointLabel",
+            "class" => "dataPointPopup",
             "visibility" => "hidden",
           })
-          t.attributes["style"] = "stroke-width: 2; fill: #000; #{style}"+
+          t.attributes["style"] = style+
             (x+txt_width > @graph_width ? "text-anchor: end;" : "text-anchor: start;")
           t.text = label.to_s
           t.attributes["id"] = t.object_id.to_s
@@ -1211,7 +1211,7 @@ module SVG
   font-weight: normal;
 }
 
-.dataPointLabel, .dataPointLabelBackground{
+.dataPointLabel, .dataPointLabelBackground, .dataPointPopup{
   fill: #000000;
   text-anchor:middle;
   font-size: 10px;
@@ -1219,8 +1219,14 @@ module SVG
   font-weight: normal;
 }
 
-.dataPointLabelBackground {
+.dataPointLabelBackground{
   stroke: #ffffff;
+  stroke-width: 2;
+}
+
+.dataPointPopup{
+  fill: #000000;
+  visibility: hidden;
   stroke-width: 2;
 }
 

--- a/lib/SVG/Graph/Graph.rb
+++ b/lib/SVG/Graph/Graph.rb
@@ -712,12 +712,11 @@ module SVG
           elsif x > @graph_width - textStr.length/2 * font_size
             style << "text-anchor: end;"
           end
-          # white background for better readability
+          # background for better readability
           @foreground.add_element( "text", {
             "x" => x.to_s,
             "y" => y.to_s,
-            "class" => "dataPointLabel",
-            "style" => "#{style} stroke: #fff; stroke-width: 2;"
+            "class" => "dataPointLabelBackground",
           }).text = textStr
           # actual label
           text = @foreground.add_element( "text", {
@@ -1212,12 +1211,17 @@ module SVG
   font-weight: normal;
 }
 
-.dataPointLabel{
+.dataPointLabel, .dataPointLabelBackground{
   fill: #000000;
   text-anchor:middle;
   font-size: 10px;
   font-family: "Arial", sans-serif;
   font-weight: normal;
+}
+
+.dataPointLabelBackground {
+  stroke: #ffffff;
+  stroke-width: 2;
 }
 
 .staggerGuideLine{

--- a/lib/SVG/Graph/Graph.rb
+++ b/lib/SVG/Graph/Graph.rb
@@ -530,8 +530,7 @@ module SVG
           t = @foreground.add_element( "text", {
             "x" => tx.to_s,
             "y" => (y - font_size).to_s,
-            "class" => "dataPointPopup",
-            "visibility" => "hidden",
+            "class" => "dataPointPopup"
           })
           t.attributes["style"] = style+
             (x+txt_width > @graph_width ? "text-anchor: end;" : "text-anchor: start;")

--- a/lib/SVG/Graph/Graph.rb
+++ b/lib/SVG/Graph/Graph.rb
@@ -532,7 +532,7 @@ module SVG
             "y" => (y - font_size).to_s,
             "class" => "dataPointPopup"
           })
-          t.attributes["style"] = style+
+          t.attributes["style"] = style +
             (x+txt_width > @graph_width ? "text-anchor: end;" : "text-anchor: start;")
           t.text = label.to_s
           t.attributes["id"] = t.object_id.to_s

--- a/lib/SVG/Graph/Graph.rb
+++ b/lib/SVG/Graph/Graph.rb
@@ -544,9 +544,9 @@ module SVG
             "r" => "#{popup_radius}",
             "style" => "opacity: 0",
             "onmouseover" =>
-              "document.getElementById(#{t.object_id}).setAttribute('visibility', 'visible' )",
+              "document.getElementById(#{t.object_id}).style.visibility ='visible'",
             "onmouseout" =>
-              "document.getElementById(#{t.object_id}).setAttribute('visibility', 'hidden' )",
+              "document.getElementById(#{t.object_id}).style.visibility = 'hidden'",
           })
         end # if add_popups
       end # add_popup

--- a/lib/SVG/Graph/Pie.rb
+++ b/lib/SVG/Graph/Pie.rb
@@ -343,7 +343,7 @@ module SVG
 
       def get_css
         return <<EOL
-.dataPointLabel, .dataPointLabelBackground{
+.dataPointLabel, .dataPointLabelBackground, .dataPointPopup{
 	fill: #000000;
 	text-anchor:middle;
 	font-size: #{datapoint_font_size}px;
@@ -351,8 +351,14 @@ module SVG
 	font-weight: normal;
 }
 
-.dataPointLabelBackground {
+.dataPointLabelBackground{
   stroke: #ffffff;
+  stroke-width: 2;
+}
+
+.dataPointPopup{
+  fill: #000000;
+  visibility: hidden;
   stroke-width: 2;
 }
 

--- a/lib/SVG/Graph/Pie.rb
+++ b/lib/SVG/Graph/Pie.rb
@@ -343,12 +343,17 @@ module SVG
 
       def get_css
         return <<EOL
-.dataPointLabel{
+.dataPointLabel, .dataPointLabelBackground{
 	fill: #000000;
 	text-anchor:middle;
 	font-size: #{datapoint_font_size}px;
 	font-family: "Arial", sans-serif;
 	font-weight: normal;
+}
+
+.dataPointLabelBackground {
+  stroke: #ffffff;
+  stroke-width: 2;
 }
 
 /* key - MUST match fill styles */


### PR DESCRIPTION
This moves most of the styling for data point labels and popups into CSS classes; see #21 for discussion.

I'm sorry about the lack of tests; unfortunately the code already in the gem is currently written in such a way that it's hard to test. I can refactor it for better testability, if that's of interest, but it will take some time (and I'd probably want to switch the tests to RSpec, or at least Minitest::Spec, in the process).