### PR TITLE
Configure CodeClimate and Travis [closes #26]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.html
 *.gem
 Gemfile.lock
+coverage
 test/*.svg
 *.orig
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: ruby
 rvm:
   - 2.2
+cache:
+  bundler: true
+  directories:
+    - /home/travis/.rvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: ruby
 rvm:
   - 2.2
-cache:
-  bundler: true
-  directories:
-    - /home/travis/.rvm
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,10 @@ language: ruby
 rvm:
   - 2.2
 cache: bundler
+
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ group :test do
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'test-unit'
-  gem 'simplecov', '< 0.18' # CodeClimate doesn't support 0.18
+  gem 'simplecov', '< 0.18', require: false # CodeClimate doesn't support 0.18
 end

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :test do
   gem 'minitest'
   gem 'minitest-reporters'
   gem 'test-unit'
+  gem 'simplecov', '< 0.18' # CodeClimate doesn't support 0.18
 end

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 SVG::Graph
 ============
 
+[![Build Status](https://travis-ci.com/marnen/svg-graph2.svg?branch=master)](https://travis-ci.com/marnen/svg-graph2)
+[![Maintainability](https://api.codeclimate.com/v1/badges/6231f5df83e017fd49fc/maintainability)](https://codeclimate.com/github/marnen/svg-graph2/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/6231f5df83e017fd49fc/test_coverage)](https://codeclimate.com/github/marnen/svg-graph2/test_coverage)
+
 Description
 -----------
 This repo is the continuation of the original [SVG::Graph library](http://www.germane-software.com/software/SVG/SVG::Graph/) by Sean Russell. I'd like to thank Claudio Bustos for giving me permissions to continue publishing the gem under it's original name: [svg-graph](https://rubygems.org/gems/svg-graph)

--- a/Rakefile
+++ b/Rakefile
@@ -25,8 +25,13 @@
 task default: %w[test]
 
 task :test do
-  ruby "test/test_data_point.rb"
-  ruby "test/test_plot.rb"
-  ruby "test/test_svg_graph.rb"
-  ruby "test/test_graph.rb"
+  [
+    "test/test_data_point.rb",
+    "test/test_plot.rb",
+    "test/test_svg_graph.rb",
+    "test/test_graph.rb"
+  ].each do |file|
+    simplecov = ENV['COVERAGE'] ? ['-r', './test/simplecov'] : []
+    ruby *(simplecov + [file])
+  end
 end

--- a/test/simplecov.rb
+++ b/test/simplecov.rb
@@ -1,0 +1,2 @@
+require 'simplecov'
+SimpleCov.start


### PR DESCRIPTION
Here's the configuration for CodeClimate and Travis that I promised in #26. To get it working on the main repo, once this PR is merged:

* Set up accounts at CodeClimate and Travis if you haven't already (a free account with GitHub integration is sufficient).
* Add the main repo to both accounts.
* For test coverage reporting, set the following environment variables in your Travis settings:
  * `COVERAGE=1` (or really anything nonempty)
  * `CC_TEST_REPORTER_ID=`[whatever test reporter ID CodeClimate gives you]; see https://docs.codeclimate.com/docs/getting-started-test-coverage for more info.
* Edit the badges in the README so they point to this project instead of my fork (which probably will just involve changing the username in the URL).

I'm just using default CodeClimate settings right now, but we'll almost certainly want to tweak them once we get a better idea of what works well for the project.