### PR TITLE
work out the number of times the scale_division needs to go in order …

### DIFF
--- a/lib/SVG/Graph/Plot.rb
+++ b/lib/SVG/Graph/Plot.rb
@@ -282,8 +282,9 @@ module SVG
 
       def get_x_values
         min_value, max_value, @x_scale_division = x_label_range
+        x_times = ((max_value-min_value)/@x_scale_division).round + 1
         rv = []
-        min_value.step( max_value + (@x_scale_division/10), @x_scale_division ) {|v| rv << v}
+        x_times.times{|v| rv << (min_value + (v * @x_scale_division))}
         return rv
       end
       alias :get_x_labels :get_x_values


### PR DESCRIPTION
…to be slightly more than the max_value, and use that, rather than relying on step, which sometimes falls short.

I've checked visually against all the percy charts, and others produced by rake.

with the exception of "plot_test_plot_axis_too_short.html" the graphs look "alright" to me.

Jon