### PR TITLE
reliable require path

### DIFF
--- a/examples/run_all.rb
+++ b/examples/run_all.rb
@@ -1,5 +1,6 @@
 # executes all examples
-require 'svggraph'
+
+require File.expand_path("#{__FILE__}/../../lib/svggraph.rb")
 
 puts SVG::Graph::VERSION
 


### PR DESCRIPTION
`bundle exec ruby run_all.rb` failed for me so I had to
modify the require.

I think it is better to require as a file instead of modifying LOAD\_PATH
to prevent loading the gem if it was installed already and `bundler` was not
used.

So I don't know. It is ugly so do with it as you please :) I thought to dump
it here anyway.